### PR TITLE
ICLR 2025 Paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - "GPTFUZZER: Red Teaming Large Language Models with Auto-Generated Jailbreak Prompts", 2023-09, [[paper]](https://www.themoonlight.io/paper/share/2ebb8387-1e7a-4607-a309-fcd46a99d2be) [[repo]](https://github.com/sherdencooper/GPTFuzz) [[site]](https://github.com/sherdencooper/GPTFuzz)
 - "Many-shot Jailbreaking", 2024-04, [[paper]](https://www.themoonlight.io/paper/share/4db82652-210c-45cc-942b-032a34e03930)
 - "Rethinking How to Evaluate Language Model Jailbreak", 2024-04, [[paper]](https://www.themoonlight.io/paper/share/44eaf8b8-2f20-4d35-a438-1fada8e091fc) [[repo]](https://github.com/controllability/jailbreak-evaluation)
+- "Confidence Elicitation: A New Attack Vector for Large Language Models", 2025-02, ICLR(poster) 25 [[paper]](https://www.themoonlight.io/paper/share/156c1cb3-c9ea-443d-9cfc-3f494f711df5) [[repo]](https://github.com/Aniloid2/Confidence_Elicitation_Attacks)
 
 ### Backdoor attack
 - "BITE: Textual Backdoor Attacks with Iterative Trigger Injection", 2022-05, ACL 23, `defense` [[paper]](https://www.themoonlight.io/paper/share/04ad5e28-6f64-46b0-8714-64a845cad49e)


### PR DESCRIPTION
Thanks for keeping track of papers with this amazing repo! Why I think this paper is relevant: Published in ICLR 2025, it directly builds on top of previous work from ICLR 2024 and AAAI 2023/2024. They discovered that it's possible to achieve attack guidance, akin to using probabilities in the gray-box attack scenario during an attack through the process of confidence elicitation. They received good scores in ICLR (5688). The code is available and can serve as a tool for word-level substitution robustness in a black-box setting on LLMs. P.S. The code is available and can serve as a tool for word-level substitution robustness in a black-box setting on LLMs. It supports confidence elicitation and empirical self-consistency as a black-box feedback signal. It also brings together three word substitution attacks (ceattacks ICLR 2025, sspattack AAAI 2024, and texthoaxer AAAI 2023). The tool is easily extendable with other search algorithms and transformations as it builds directly on top of TextAttack.