### PR TITLE
Add Veritensor to the tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
-- [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor) - [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor): Open-source scanner for AI models to detects Pickle/PyTorch malware, check licenses, and verifie HF hashes. ![GitHub Repo stars](https://img.shields.io/github/stars/ArseniiBrazhnyk/Veritensor?style=social)
+- [Veritensor](https://github.com/arsbr/Veritensor): Shift-left security for RAG pipelines. Scans documents (PDF, Docx) and datasets for stealth prompt injections and PII before vector database ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/ArseniiBrazhnyk/Veritensor?style=social)
   
 ## Articles
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
-
+- [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor) - [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor): Open-source scanner for AI models to detects Pickle/PyTorch malware, check licenses, and verifie HF hashes. ![GitHub Repo stars](https://img.shields.io/github/stars/ArseniiBrazhnyk/Veritensor?style=social)
+  
 ## Articles
 
 - [Hacking Auto-GPT and escaping its docker container](https://positive.security/blog/auto-gpt-rce)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
-- [Veritensor](https://github.com/arsbr/Veritensor): Shift-left security for RAG pipelines. Scans documents (PDF, Docx) and datasets for stealth prompt injections and PII before vector database ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/ArseniiBrazhnyk/Veritensor?style=social)
+- [Veritensor](https://github.com/arsbr/Veritensor): Shift-left security for RAG pipelines. Scans documents (PDF, Docx) and datasets for stealth prompt injections and PII before vector database ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
   
 ## Articles
 


### PR DESCRIPTION
Hi! I would like to propose adding Veritensor to the tools section.
While many LLM security tools focus on runtime filtering (firewalls), Veritensor focuses on **Shift-Left Security for RAG and Data Ingestion.**

**Key Differentiators:**
1.  **RAG Document Scanning:** It scans raw documents (PDF, Docx, HTML) for stealth prompt injections (e.g., hidden CSS, white text) and PII before they are embedded into a Vector DB.
2.  **Dataset Poisoning Detection:** Streams and scans massive datasets (Parquet, CSV) for malicious URLs and poisoned instructions.
3.  **Native Integrations:** Provides security wrappers for LangChain and LlamaIndex loaders to block threats in-memory.

*   **Repo:** https://github.com/arsbr/Veritensor
*   **License:** Apache 2.0
*   **Install:** `pip install veritensor`


Proposed entry for the README.md:
- [Veritensor](https://github.com/arsbr/Veritensor) - Shift-left security for RAG pipelines. Scans documents (PDF, Docx) and datasets for stealth prompt injections and PII before vector database ingestion.

I believe this tool provides a necessary layer of "Data Hygiene" that complements existing runtime LLM scanners. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * Tools 섹션에 Veritensor 항목을 추가하여 목록에 새 도구를 포함했습니다.
  * Veritensor에 대한 간단한 설명과 별(star) 배지를 표시하도록 업데이트했습니다.
  * 이전에 있던 잘못된 "-" 항목을 제거하고 항목 서식과 공백을 정리하여 문서 가독성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->