### PR TITLE
Add Omega Walls to README tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
+- [Omega Walls](https://github.com/synqratech/omega-walls) — Deterministic Ω trust-layer for RAG/agents: projects untrusted text into wall-pressures, accumulates scar-mass, triggers auditable Off decisions.
 
 ## Articles
 


### PR DESCRIPTION
Adds Omega Walls (synqratech/omega-walls) to the Tools section as an open-source, deterministic safety layer for prompt-injection / tool-abuse in RAG & agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서
* README에 새로운 도구 항목을 Tools 섹션에 추가했습니다.
* README의 Contributions 리스트에 새로운 항목을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->