### PR TITLE
Add: Breaking Agent Backbones paper (ICLR 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - "AgentDojo: A Dynamic Environment to Evaluate Attacks and Defenses for LLM Agents", 2024-06, NeurIPS 24, [[paper]](https://www.themoonlight.io/paper/share/5a567ace-0218-4c76-9018-6f99a93df7cd) [[repo]](https://github.com/ethz-spylab/agentdojo) [[site]](https://agentdojo.spylab.ai/)
 - "Formalizing and Benchmarking Prompt Injection Attacks and Defenses", 2024-08, USENIX Security 24, [[paper]](https://www.themoonlight.io/paper/share/cd17769a-b23f-4be0-8078-938f9d4fd827), [[repo]](https://github.com/liu00222/Open-Prompt-Injection)
 - "AgentHarm: A Benchmark for Measuring Harmfulness of LLM Agents", 2024-10, [[paper]](https://www.themoonlight.io/paper/share/7ab99274-2085-4b67-8941-c5a9f8310ebb)
-- "Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents", 2025-10, ICLR 26, `agent`, [[paper]](https://arxiv.org/abs/2510.22620)
+- "Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents", 2025-10, ICLR 26, `agent`, [[paper]](https://arxiv.org/abs/2510.22620) [[code]](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/b3) [[dataset]](https://huggingface.co/datasets/Lakera/b3-agent-security-benchmark-weak)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - "AgentDojo: A Dynamic Environment to Evaluate Attacks and Defenses for LLM Agents", 2024-06, NeurIPS 24, [[paper]](https://www.themoonlight.io/paper/share/5a567ace-0218-4c76-9018-6f99a93df7cd) [[repo]](https://github.com/ethz-spylab/agentdojo) [[site]](https://agentdojo.spylab.ai/)
 - "Formalizing and Benchmarking Prompt Injection Attacks and Defenses", 2024-08, USENIX Security 24, [[paper]](https://www.themoonlight.io/paper/share/cd17769a-b23f-4be0-8078-938f9d4fd827), [[repo]](https://github.com/liu00222/Open-Prompt-Injection)
 - "AgentHarm: A Benchmark for Measuring Harmfulness of LLM Agents", 2024-10, [[paper]](https://www.themoonlight.io/paper/share/7ab99274-2085-4b67-8941-c5a9f8310ebb)
-- "Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents", 2025-10, ICLR 26, `agent`, [[paper]](https://arxiv.org/abs/2510.22620) [[code]](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/b3) [[dataset]](https://huggingface.co/datasets/Lakera/b3-agent-security-benchmark-weak)
+- "Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents", 2025-10, ICLR 26, `agent`, [[paper]](https://arxiv.org/abs/2510.22620) [[repo]](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/b3) [[dataset]](https://huggingface.co/datasets/Lakera/b3-agent-security-benchmark-weak)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - "AgentDojo: A Dynamic Environment to Evaluate Attacks and Defenses for LLM Agents", 2024-06, NeurIPS 24, [[paper]](https://www.themoonlight.io/paper/share/5a567ace-0218-4c76-9018-6f99a93df7cd) [[repo]](https://github.com/ethz-spylab/agentdojo) [[site]](https://agentdojo.spylab.ai/)
 - "Formalizing and Benchmarking Prompt Injection Attacks and Defenses", 2024-08, USENIX Security 24, [[paper]](https://www.themoonlight.io/paper/share/cd17769a-b23f-4be0-8078-938f9d4fd827), [[repo]](https://github.com/liu00222/Open-Prompt-Injection)
 - "AgentHarm: A Benchmark for Measuring Harmfulness of LLM Agents", 2024-10, [[paper]](https://www.themoonlight.io/paper/share/7ab99274-2085-4b67-8941-c5a9f8310ebb)
+- "Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents", 2025-10, ICLR 26, `agent`, [[paper]](https://arxiv.org/abs/2510.22620)
 
 ## Tools
 


### PR DESCRIPTION
Our work recently has been accepted to ICLR and I believe it could be of interest!

The PR adds the paper **[Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents](https://arxiv.org/abs/2510.22620)** to the **Benchmark** section.

**What the paper does:** Introduces "threat snapshots" — a framework identifying specific execution points where LLM vulnerabilities manifest and propagate to agent-level risks. Presents the b³ benchmark, built from 194,331 crowdsourced adversarial attacks, evaluating 34 LLMs. Key finding: reasoning capability (not model size) correlates with security. Benchmark, dataset, and evaluation code are publicly released.

Thanks for reviewing!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 기여도 및 벤치마크 섹션에 새 논문 항목 추가: "Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents" (ICLR 2025). 논문 및 코드/데이터셋 링크가 함께 포함되어 관련 연구와 재현 자료에 대한 참조를 제공함.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->