### PR TITLE
Add OpenObscure to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [Prompt Fuzzer](https://github.com/prompt-security/ps-fuzz): the open-source tool to help you harden your GenAI applications ![GitHub Repo stars](https://img.shields.io/github/stars/prompt-security/ps-fuzz?style=social)
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
+- [OpenObscure](https://github.com/openobscure/openobscure) - On-device privacy firewall for AI agents. Encrypts PII with FF1 format-preserving encryption before it reaches the LLM, with image redaction and cognitive firewall for response manipulation.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 
 ## Articles

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [Prompt Fuzzer](https://github.com/prompt-security/ps-fuzz): the open-source tool to help you harden your GenAI applications ![GitHub Repo stars](https://img.shields.io/github/stars/prompt-security/ps-fuzz?style=social)
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
-- [OpenObscure](https://github.com/openobscure/openobscure) - On-device privacy firewall for AI agents. Encrypts PII with FF1 format-preserving encryption before it reaches the LLM, with image redaction and cognitive firewall for response manipulation.
+- [OpenObscure](https://github.com/openobscure/openobscure): On-device privacy firewall for AI agents. Encrypts PII with FF1 format-preserving encryption before it reaches the LLM, with image redaction and cognitive firewall for response manipulation. ![GitHub Repo stars](https://img.shields.io/github/stars/openobscure/openobscure?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 
 ## Articles


### PR DESCRIPTION
## Summary

- Adds [OpenObscure](https://github.com/openobscure/openobscure) to the Tools section
- OpenObscure is an on-device privacy firewall for AI agents that encrypts PII with FF1 format-preserving encryption before it reaches the LLM, with image redaction and a cognitive firewall for response manipulation
- Entry placed in alphabetical order within the existing Tools list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * Tools 섹션에 OpenObscure 항목 추가 — GitHub 링크 및 스타 배지 포함. 온디바이스 프라이버시 방화벽으로 PII의 FF1 형식 보존 암호화, 이미지 가림(레드액션) 기능, 응답 출력 조작 제어 등 사용자가 볼 수 있는 기능 설명을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->