### PR TITLE
Add Wraith Academy and wraith-challenges links

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [LLM Security Problems at DEFCON31 Quals](https://github.com/Nautilus-Institute/quals-2023/tree/main/pawan_gupta): the world's top security competition
 - [PromptBounty.io](https://sites.google.com/view/promptbounty/)
 - [PALLMs (Payloads for Attacking Large Language Models)](https://github.com/mik0w/pallms)
+- [Wraith Academy](https://wraith.sh/academy): hands-on AI pentest curriculum with CTF-style challenges against live LLM agents
+- [wraith-challenges](https://github.com/gh0stshe11/wraith-challenges): standalone open-source AI security CTF challenges using a hybrid LLM + deterministic trigger architecture. Single-file Python, MIT.
 
 ## Other Useful Resources
 


### PR DESCRIPTION
- **Wraith Academy** — hands-on AI pentest training curriculum. Fits the [Training / Education / whichever section you added to].
- **wraith-challenges** — open-source CTF challenges. Fits the [Tools / CTF / Resources section].

Disclosure: I'm the maintainer of both. Happy to adjust descriptions if the framing doesn't match the list's conventions, or remove either entry if you don't think it's a fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * README에 두 개의 새로운 AI 보안 관련 프로젝트 링크 추가: Wraith Academy (AI 침투 테스트 커리큘럼 및 CTF 스타일 챌린지) 및 wraith-challenges (오픈소스 AI 보안 CTF 챌린지)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->