### PR TITLE
Add peyeeye to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
+- [peyeeye](https://peyeeye.ai): PII redaction and rehydration API for LLM prompts — strip emails, cards, secrets, and 60+ entity types before the model sees them, then put the originals back in the response. Stateful sessions or stateless AEAD-sealed blobs, with Python + TypeScript SDKs and drop-ins for Vercel AI SDK, LangChain, and LiteLLM. ![GitHub Repo stars](https://img.shields.io/github/stars/peyeeye/peyeeye-python?style=social)
 
 ## Articles
 


### PR DESCRIPTION
Adds [peyeeye](https://peyeeye.ai) to the Tools section.

peyeeye is a PII redaction and rehydration API for LLM prompts. It handles the full roundtrip: strip emails, payment data, secrets, government IDs, and 60+ entity types from prompts before they reach the model, then rehydrate the originals into the response. Custom entities are first-class for domain-specific identifiers. Two deployment modes — stateful sessions or stateless AEAD-sealed rehydration keys (`skey_…`) for zero-retention setups.

Ships with Python + TypeScript SDKs and drop-in middleware for the Vercel AI SDK, LangChain, LangChain.js, and LiteLLM.

**Disclosure:** I'm the author/maintainer of peyeeye. Happy to adjust wording/placement if you'd like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * README의 도구 목록에 'peyeeye' 항목이 추가되었습니다 — PII(개인정보) 제거 및 복원 기능, Stateful/Stateless 옵션, SDK/드롭인 지원을 설명하는 상세 안내와 함께 관련 링크 및 GitHub 스타 배지가 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->