### PR TITLE
Add OWASP Agent Memory Guard to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
+- [OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard): runtime middleware that intercepts LLM tool-call outputs (PreToolUse/PostToolUse) to block prompt injection and memory poisoning before they reach the model context. Part of the OWASP Agentic Security Initiative.
 
 ## Articles
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
-- [OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard): runtime middleware that intercepts LLM tool-call outputs (PreToolUse/PostToolUse) to block prompt injection and memory poisoning before they reach the model context. Part of the OWASP Agentic Security Initiative.
+- [OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard): runtime middleware that intercepts LLM tool-call outputs (PreToolUse/PostToolUse) to block prompt injection and memory poisoning before they reach the model context. Part of the OWASP Agentic Security Initiative. ![GitHub Repo stars](https://img.shields.io/github/stars/OWASP/www-project-agent-memory-guard?style=social)
 
 ## Articles
 


### PR DESCRIPTION
Added OWASP Agent Memory Guard to the list of tools in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서 개선**
  * README.md의 Tools 섹션에 **OWASP Agent Memory Guard** 항목(링크 및 도구 설명)을 추가했습니다.
  * LLM tool-call 과정에서 프롬프트 인젝션 및 메모리 포이즈닝을 차단하는 런타임 미들웨어로 소개합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->