### PR TITLE
Add Armorer Guard to LLM security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [Garak](https://github.com/leondz/garak/): a LLM vulnerability scanner ![GitHub Repo stars](https://img.shields.io/github/stars/leondz/garak?style=social)
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer): a fuzzing framework for LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/mnns/LLMFuzzer?style=social)
 - [LLM Guard](https://github.com/laiyer-ai/llm-guard): a security toolkit for LLM Interactions ![GitHub Repo stars](https://img.shields.io/github/stars/laiyer-ai/llm-guard?style=social)
+- [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard): a local Rust scanner and MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments. ![GitHub Repo stars](https://img.shields.io/github/stars/ArmorerLabs/Armorer-Guard?style=social)
 - [Vigil](https://github.com/deadbits/vigil-llm): a LLM prompt injection detection toolkit ![GitHub Repo stars](https://img.shields.io/github/stars/deadbits/vigil-llm?style=social)
 - [jailbreak-evaluation](https://github.com/controllability/jailbreak-evaluation): an easy-to-use Python package for language model jailbreak evaluation ![GitHub Repo stars](https://img.shields.io/github/stars/controllability/jailbreak-evaluation?style=social)
 - [Prompt Fuzzer](https://github.com/prompt-security/ps-fuzz): the open-source tool to help you harden your GenAI applications ![GitHub Repo stars](https://img.shields.io/github/stars/prompt-security/ps-fuzz?style=social)


### PR DESCRIPTION
Adds Armorer Guard to the Tools section. I maintain Armorer Guard at Armorer Labs; it is an MIT-licensed local Rust scanner/MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * README의 Tools 섹션에 "Armorer Guard" 항목이 추가되었습니다.
  * GitHub Stars 배지 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->