### PR TITLE
Add IronClaw to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
+- [IronClaw](https://github.com/IronSecCo/ironclaw): a security-hardened, self-hosted runtime that sandboxes untrusted AI agents in gVisor with network-off isolation, host-side credential injection, and a human-approval gateway ![GitHub Repo stars](https://img.shields.io/github/stars/IronSecCo/ironclaw?style=social)
 
 ## Articles
 


### PR DESCRIPTION
Adds [IronClaw](https://github.com/IronSecCo/ironclaw) to the **Tools** section.

IronClaw is a security-hardened, self-hosted runtime that sandboxes untrusted AI agents: each agent runs in a per-conversation gVisor (`runsc`) sandbox with `network=none`, a read-only rootfs, and dropped capabilities; the model-provider key is injected host-side and never enters the box; and every capability change is held at a human-approval gateway. This makes it a defensive control for containing prompt-injected or compromised agents.

Single entry, follows the section's `- [Name](url): description ![stars]` format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `Tools` 섹션에 `IronClaw` 항목이 추가되었습니다.
  * 보안이 강화된 self-hosted 런타임으로서의 특징과 샌드박스, 네트워크 격리, 승인 게이트웨이 관련 안내가 포함되었습니다.
  * 관련 링크 및 상태 배지가 함께 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->