### PR TITLE
Add signalbench (IBSC) to Benchmark section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - "AgentDojo: A Dynamic Environment to Evaluate Attacks and Defenses for LLM Agents", 2024-06, NeurIPS 24, [[paper]](https://www.themoonlight.io/paper/share/5a567ace-0218-4c76-9018-6f99a93df7cd) [[repo]](https://github.com/ethz-spylab/agentdojo) [[site]](https://agentdojo.spylab.ai/)
 - "Formalizing and Benchmarking Prompt Injection Attacks and Defenses", 2024-08, USENIX Security 24, [[paper]](https://www.themoonlight.io/paper/share/cd17769a-b23f-4be0-8078-938f9d4fd827), [[repo]](https://github.com/liu00222/Open-Prompt-Injection)
 - "AgentHarm: A Benchmark for Measuring Harmfulness of LLM Agents", 2024-10, [[paper]](https://www.themoonlight.io/paper/share/7ab99274-2085-4b67-8941-c5a9f8310ebb)
+- "In-Band Signal Compliance (IBSC): One Metric for Prompt Injection and Temporal Blindness", 2026-07, [[paper]](https://doi.org/10.5281/zenodo.21223956), [[repo]](https://github.com/mthamil107/signal-compliance), [[dataset]](https://huggingface.co/datasets/thamilvendhan/signalbench)
 
 ## Tools
 


### PR DESCRIPTION
Adds **signalbench / In-Band Signal Compliance (IBSC)** to the Benchmark section.

It's an open-source (Apache-2.0) benchmark that unifies **prompt injection** (over-compliance) and ignoring legitimate signals like access-deny / do-not-share / injected dates (under-compliance) into one metric, evaluated across 21 models.

- Repo: https://github.com/mthamil107/signal-compliance
- Dataset/leaderboard: https://huggingface.co/datasets/thamilvendhan/signalbench
- DOI: https://doi.org/10.5281/zenodo.21223956

Zero-dependency, deterministic action-based grading, raw per-item results released. Fits alongside AgentDojo / AgentHarm in the Benchmark list. Thanks for maintaining this list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 벤치마크 목록에 **In-Band Signal Compliance (IBSC)** 항목이 새로 추가되었습니다.
  * 해당 항목에서 논문, 저장소, 데이터셋 링크를 함께 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->