### PR TITLE
Add AiWiki: LLM Privacy Protection (encyclopedia of LLM privacy attacks & defenses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [LLM Security Problems at DEFCON31 Quals](https://github.com/Nautilus-Institute/quals-2023/tree/main/pawan_gupta): the world's top security competition
 - [PromptBounty.io](https://sites.google.com/view/promptbounty/)
 - [PALLMs (Payloads for Attacking Large Language Models)](https://github.com/mik0w/pallms)
+- [AiWiki: LLM Privacy Protection](https://xuebinma.github.io/AIWiki/en/privacy/): an engineer-facing encyclopedia of LLM privacy attacks and defenses — leak mechanisms (memorization extraction, membership inference, embedding inversion), actionable mitigation recipes, and real incidents, organized along LLM history (bilingual EN/中文)
 
 ## Other Useful Resources
 


### PR DESCRIPTION
Adds [AiWiki: LLM Privacy Protection](https://xuebinma.github.io/AIWiki/en/privacy/) under **Other Awesome Projects**.

It is an engineer-facing encyclopedia of LLM privacy attacks and defenses, written from the AI's first-person perspective (with a strict rule against fake introspection — only externally observable behavior is stated as fact). It covers leak mechanisms (memorization extraction, membership inference, embedding inversion, RAG/agent leakage), actionable mitigation recipes, and a real-incident index, organized along LLM history in six volumes. Every entry tags its evidence (papers / vendor docs / advisories) and is version-stamped. Bilingual EN/中文, CC BY-SA 4.0.

Repo: https://github.com/XuebinMa/AIWiki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * README의 “Other Awesome Projects” 목록에 LLM 프라이버시 공격·방어 및 관련 이슈를 다루는 AiWiki 프로젝트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->