### PR TITLE
Add AgentSentry Gateway to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
+- [AgentSentry Gateway](https://github.com/akav-labs/agentsentry-gateway): transparent OpenAI-compatible security gateway that scans LLM traffic for secret/PII leaks, jailbreaks, and prompt injection at the egress ![GitHub Repo stars](https://img.shields.io/github/stars/akav-labs/agentsentry-gateway?style=social)
 
 ## Articles
 


### PR DESCRIPTION
Adds **AgentSentry Gateway** to the Tools section.

It's a transparent, OpenAI-compatible security gateway (Rust, Apache-2.0) that sits in front of LLM/agent traffic and scans every request at the egress for secret/PII leaks, jailbreaks, and prompt injection — blocking violations and forwarding clean traffic untouched. It also normalizes Unicode homoglyphs before matching to resist look-alike evasion. Fits alongside the other inline defensive tools here (LLM Guard, Rebuff, Vigil).

Repo: https://github.com/akav-labs/agentsentry-gateway

Single line added under `## Tools`, matching the existing `[Name](url): description + stars-badge` format. Thanks for maintaining the list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * README의 **Tools** 섹션에 **AgentSentry Gateway** 항목을 추가했습니다(링크 및 GitHub stars 배지 포함).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->