### PR TITLE
Add OWASP Agent Memory Guard to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 ## Tools
 
 - [UTCP](https://github.com/universal-tool-calling-protocol/): Secure, direct tool-calling to any native endpoint for your AI agent
+- [OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard): runtime defense that screens AI-agent memory reads/writes for poisoning, injection, and secret leakage; reference implementation for OWASP ASI06 (Memory & Context Poisoning) ![GitHub Repo stars](https://img.shields.io/github/stars/OWASP/www-project-agent-memory-guard?style=social)
 - [Plexiglass](https://github.com/kortex-labs/plexiglass): a security toolbox for testing and safeguarding LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=social)
 - [PurpleLlama](https://github.com/facebookresearch/PurpleLlama): set of tools to assess and improve LLM security. ![GitHub Repo stars](https://img.shields.io/github/stars/facebookresearch/PurpleLlama?style=social)
 - [Rebuff](https://github.com/protectai/rebuff): a self-hardening prompt injection detector ![GitHub Repo stars](https://img.shields.io/github/stars/protectai/rebuff?style=social)


### PR DESCRIPTION
Adds OWASP Agent Memory Guard to the Tools section.

It's an OWASP Incubator project and the reference implementation for **ASI06 (Memory & Context Poisoning)** from the OWASP Top 10 for Agentic Applications — a defense category the list doesn't currently cover. Existing tools here screen prompts at the front of the loop; this one screens the memory store itself, which is a different surface (poisoned memory persists across sessions — see Cisco's MemoryTrap disclosure, MINJA, AgentPoison).

- Apache-2.0, actively maintained, 12k+ downloads
- Detector pipeline + YAML policy (allow/redact/quarantine/block), integrity baselines, snapshots/rollback
- Reproducible 55-payload benchmark in-repo
- Integrations: LangChain, OpenAI Agents SDK, AutoGen, mem0, CrewAI

https://github.com/OWASP/www-project-agent-memory-guard

Disclosure: I lead the project. Happy to adjust the wording or move it if you'd prefer it elsewhere in the list.