### PR TITLE
Add Vetto: daemon-less kernel sandbox for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Contributions are always welcome. Please read the [Contribution Guidelines](CONT
 - [Prompt Fuzzer](https://github.com/prompt-security/ps-fuzz): the open-source tool to help you harden your GenAI applications ![GitHub Repo stars](https://img.shields.io/github/stars/prompt-security/ps-fuzz?style=social)
 - [WhistleBlower](https://github.com/Repello-AI/whistleblower): open-source tool designed to infer the system prompt of an AI agent based on its generated text outputs. ![GitHub Repo stars](https://img.shields.io/github/stars/Repello-AI/whistleblower?style=social)
 - [Open-Prompt-Injection](https://github.com/liu00222/Open-Prompt-Injection): open-source tool to evaluate prompt injection attacks and defenses on benchmark datasets. ![GitHub Repo stars](https://img.shields.io/github/stars/liu00222/Open-Prompt-Injection?style=social)
-- [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
+- [Agentic Radar](https://github.com/splx-ai/agentic-radar): Open-source CLI security scanner for agentic workflows.
+- [Vetto](https://github.com/shleder/vetto): daemon-less kernel sandbox for AI coding agents (Landlock/seccomp/namespaces on Linux, Seatbelt on macOS) — blocks secret exfiltration and unapproved egress with `vetto enable <agent>`. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 
 ## Articles
 


### PR DESCRIPTION
Adds Vetto to Tools.

Vetto (https://github.com/shleder/vetto, Apache-2.0) is a daemon-less kernel sandbox for AI coding agents: Landlock/seccomp/namespaces on Linux, Seatbelt on macOS. `vetto enable <agent>` wraps Claude Code / Codex CLI / 18 more agents so secret reads (~/.ssh, ~/.aws, .env) and off-allowlist egress are denied by the kernel, with Git Guard against destructive git ops.

Disclosure: I am the author/maintainer of Vetto.